### PR TITLE
Allow the caller to disable selection within the preview document

### DIFF
--- a/PrintDialogX/PrintDialog.cs
+++ b/PrintDialogX/PrintDialog.cs
@@ -40,6 +40,11 @@ namespace PrintDialogX.PrintDialog
         public bool ShowInTaskbar { get; set; } = false;
 
         /// <summary>
+        /// Gets or sets whether the user is allowed to select ranges in the preview document. (Default: true)
+        /// </summary>
+        public bool EnableSelection { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets whether the dialog offers the "Pages" option in print settings, which contains "All Pages", "Current Page", and "Custom Pages".
         /// </summary>
         public bool AllowPagesOption { get; set; } = true;

--- a/PrintDialogX/PrintPage.xaml.cs
+++ b/PrintDialogX/PrintPage.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Printing;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -47,6 +48,8 @@ namespace PrintDialogX.Internal
             Common.DoEvents();
 
             _owner = owner;
+
+            previewer.IsSelectionEnabled = dialog.EnableSelection;
 
             _allowPages = dialog.AllowPagesOption;
             _allowPageOrder = dialog.AllowPageOrderOption;

--- a/PrintDialogX/UserControls/NoKeypadDocumentViewer.cs
+++ b/PrintDialogX/UserControls/NoKeypadDocumentViewer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Windows.Controls;
 using System.Windows.Automation.Peers;
+using System.Reflection;
 
 namespace PrintDialogX.Internal.UserControls
 {
@@ -8,6 +9,31 @@ namespace PrintDialogX.Internal.UserControls
         protected override AutomationPeer OnCreateAutomationPeer()
         {
             return new FrameworkElementAutomationPeer(this);
+        }
+
+        protected override void OnDocumentChanged()
+        {
+            base.OnDocumentChanged();
+            SetIsSelectionEnabled();
+        }
+
+        bool _isSelectionEnabled;
+
+        public bool IsSelectionEnabled
+        {
+            get => _isSelectionEnabled;
+            set
+            {
+                _isSelectionEnabled = value;
+                SetIsSelectionEnabled();
+            }
+        }
+
+        static PropertyInfo s_IsSelectionEnabled_property = typeof(DocumentViewer).GetProperty("IsSelectionEnabled", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        void SetIsSelectionEnabled()
+        {
+            s_IsSelectionEnabled_property?.SetValue(this, _isSelectionEnabled);
         }
     }
 }


### PR DESCRIPTION
The WPF `DocumentViewer` control automatically allows the user to select elements in the document by clicking and dragging. The ability to do this is controlled by a property `IsSelectionEnabled`, which Microsoft, in their infinite wisdom, have chosen to make `internal` to the `DocumentViewer` class. Reflection can be used to set it to false, but a complicating factor is that `DocumentViewerBase` sets it back to true every time it attaches a new document to the control. Again, why? 😛 

This PR adds a new property `EnableSelection` to the `PrintDialog` top-end configuration class.

The code is already subclassing `DocumentViewer` as `NoKeypadDocumentViewer`. This PR augments this subclass with a property `IsSelectionEnabled` of its own, and adds code using reflection to assign its value to the base class' secret `IsSelectionEnabled`.

These two properties are wired up in the `PrintPage` constructor.

It turns out that `DocumentViewer` aggressively resets `IsSelectionEnabled` to `true` for some reason. In particular, every time it attaches a new document to the control, it gets set to `true`. This happens as a side-effect of a method `OnDocumentChanged` which *is* visible to subclasses and can be overridden. So this PR also updates `NoKeypadDocumentViewer` to reapply the `IsSelectionEnabled` value every time `OnDocumentChanged` fires.

**This has an unintended beneficial side-effect: The crashes reported in #7 stop happening if selection is disabled!** I wasn't expecting that but I'll take it. 🙂 